### PR TITLE
correct the build path of grunt-less

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,7 +145,6 @@ module.exports = function(grunt) {
               '!inyoka_theme_ubuntuusers/static/style/*-sprite.less',
               '!inyoka_theme_ubuntuusers/static/style/*.m.less'
             ],
-            dest: 'inyoka_theme_ubuntuusers/static/style/',
             ext: '.css',
           },
           {


### PR DESCRIPTION
before, the css were generated into the directory
`./inyoka_theme_ubuntuusers/static/style/inyoka_theme_ubuntuusers/static/style/`
 (yes, the second part is no c&p-error…)
