### PR TITLE
Integrated startpage search

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/main.less
+++ b/inyoka_theme_ubuntuusers/static/style/main.less
@@ -11,6 +11,7 @@
 @import 'fonts.less';
 @import 'layout.less';
 @import 'main-sprite.less';
+@import 'search.less';
 
 /*
  * Liberation Sans

--- a/inyoka_theme_ubuntuusers/static/style/search.less
+++ b/inyoka_theme_ubuntuusers/static/style/search.less
@@ -1,0 +1,92 @@
+/**
+ * style.search
+ * ~~~~~~~~~~~~
+ *
+ * Some hacky style-definitions for the search-field.
+ *
+ * :copyright: (c) 2007-2015 by the Inyoka Team, see AUTHORS for more details.
+ * :license: BSD, see LICENSE for more details.
+ */
+
+@import 'fonts.less';
+
+form.search {
+  float:right;
+  
+  img { /* startpage icon */
+    max-height: 2em;
+    vertical-align: bottom;
+  }
+  
+  .search_query { /* text-input-field for the search-words */
+    font-family: @font-content;
+    border: solid 1px #888;
+    background-color: #fefefe;
+    width: 10.0em;
+    
+    background-image: url(../img/icons/small/portal.png);
+    background-repeat: no-repeat;
+    background-position: 1px 1px;
+    padding: 1px 1px 1px 22px;
+  }
+  
+  input[type=submit] {
+    background: url(../img/search.png);
+    background-color: #eee;
+    color:#333333;
+    background-repeat: no-repeat;
+    background-position: left center;
+    padding: 0px;
+    padding-left: 18px;
+    &:hover {
+      background-color:#FFFFFF;
+    }
+  }
+
+  .search_expander { /* little down-arrow at the righbottom of the search-location-selector (→ just eyecandy) */
+    cursor: pointer;
+    margin-top: -20px;
+    position: absolute;
+    background-image: url(../img/search_expander.png);
+    background-position: 11px 13px;
+    background-repeat: no-repeat;
+    width: 20px;
+    height: 18px;
+  }
+  
+  ul.search_area { /* a popup where the search-location can be selected */
+    position: absolute;
+    z-index: 99;
+    margin-top: 19px;
+    line-height: 1em;
+    list-style: none;
+    border: solid 1px #888;
+    background-color: #fefefe;
+    padding: 0;
+    li {
+      padding: 0.3em 0.4em 0.3em 18px;
+      cursor: pointer;
+      color: black;
+      background: transparent url(../img/icons/small/portal.png) left no-repeat;
+    }
+    li.active {
+      font-weight: bold;
+    }
+    li:hover {
+      background-color: #eee;
+    }
+  }
+}
+
+form.search ul.search_area li.area_wiki, .search input.area_wiki {
+  background-image: url(../img/icons/small/wiki.png);
+}
+form.search ul.search_area li.area_forum, .search input.area_forum {
+  background-image: url(../img/icons/small/forum.png);
+}
+form.search ul.search_area li.area_planet, .search input.area_planet {
+  background-image: url(../img/icons/small/planet.png);
+}
+form.search ul.search_area li.area_ikhaya, .search input.area_ikhaya {
+  background-image: url(../img/icons/small/ikhaya.png);
+}

--- a/inyoka_theme_ubuntuusers/templates/overall.html
+++ b/inyoka_theme_ubuntuusers/templates/overall.html
@@ -138,6 +138,19 @@
       </div>{# .appheader #}
 
       <div class="pathbar">
+        
+        {# search via startpage
+           requires JS to work #}
+        <form method=POST accept-charset="UTF-8" action='https://startpage.com/do/search' class="search" name="searchsys" data-active-app="{{ active_app }}"> 
+          <div>
+            <input type="text" name="keyword" class="search_query" />
+            <input type="hidden" name="query">
+            <input value="deutsch" type="hidden" name="language">
+            
+            <input type="submit" value="{% trans %}Search{% endtrans %}" class="search_submit" /> via <img src="https://startpage.com/graphics/startpage_searchbox_logo.jpg" />
+          </div>
+        </form>
+        
         {% block pathbar_extensions %}
         {% endblock %}
 


### PR DESCRIPTION
After removing the portalintern search, this is a temporary workaround using startpage. https://startpage.com/

Searching on subdomains (ikhaya, wiki etc.) is possible. Looks identical to the old search (except the startpage-logo).

known issues
- relies fully on JS (search wit JS disabeld, will only open up a general startpage-search)
- no translation (ok, general lack in JS)

<del>
if you open the list of search areas/domains, however select no item, the list will stay open. Clicking on the icon that opend the list or another item resolves it. Ideas/dont mind?
</del>
