### PR TITLE
Fixed #49 -- removed general margin for p-tag in ikhaya

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/ikhaya.less
+++ b/inyoka_theme_ubuntuusers/static/style/ikhaya.less
@@ -63,9 +63,7 @@ h3.title {
     text-decoration: none;
   }
 }
-p {
-  margin-bottom: 0.5em;
-}
+
 div.intro {
   margin: 0 1.5em;
   font-style: italic;


### PR DESCRIPTION
Simply removed the rule, because we have a [general one in main.less](https://github.com/inyokaproject/theme-ubuntuusers/blob/staging/inyoka_theme_ubuntuusers/static/style/main.less#L619).
