### PR TITLE
Disabled justify

### DIFF
--- a/inyoka_theme_ubuntuusers/static/planet/style/index.m.less
+++ b/inyoka_theme_ubuntuusers/static/planet/style/index.m.less
@@ -22,6 +22,5 @@ article {
 
   p.meta {
     font-size: 0.9em;
-    text-align: right !important; /*override justify from #content p*/
   }
 }

--- a/inyoka_theme_ubuntuusers/static/style/main.less
+++ b/inyoka_theme_ubuntuusers/static/style/main.less
@@ -622,11 +622,8 @@ table.syntaxtable {
   padding: 0 0 0 20px;
   p {
     margin: 0.7em 0.0em;
-    text-align: justify;
   }
-  li {
-    text-align: justify;
-  }
+
   .message {
     margin: 0.0em;
     margin-bottom: 1.0em;

--- a/inyoka_theme_ubuntuusers/static/style/overall.m.less
+++ b/inyoka_theme_ubuntuusers/static/style/overall.m.less
@@ -156,7 +156,6 @@ header{
 
   p {
     margin-top: 0;
-    text-align: justify;
   }
 
   li p {


### PR DESCRIPTION
Justify is only good for readability, if `hyphenation: auto` is enabled.

However, Chrom{e,ium} and Android dont support this CSS-feature atm. (see http://caniuse.com/#feat=css-hyphens)

Only workaround would be to use some JS – imho it is more easier and a crossplattform solution to disable justify.
