### PR TITLE
Search: On middleclick display results in new tab

### DIFF
--- a/inyoka_theme_ubuntuusers/static/js/overall.js
+++ b/inyoka_theme_ubuntuusers/static/js/overall.js
@@ -235,6 +235,21 @@ $(document).ready(function () {
     });
     $('form.search').append(expander);
 
+    /* if an middleclick appears on the submit-button, `target=_blank` is
+     * added as attribute to the search-form. Thus, the page with the
+     * search results will open up in a new tab.
+     *
+     * Could couse a pop-up-warning.
+     */
+    $("form.search input[type=submit]").mousedown(function(event) {
+      if(event.which === 2) {
+        $("form.search").attr('target','_blank');
+        $("form.search").submit();
+      } else {
+        $("form.search").removeAttr('target');
+      }
+    });
+
     $(document).click(function (e) {
       if(e.target.className != "search_expander") {
         popup.hide();


### PR DESCRIPTION
Method tested on
- Chrom{e, ium}: does not need this JS-piece, as it
                has the feature nativly; however, works
- Firefox: opens a popup-warning

requested in http://forum.ubuntuusers.de/post/7392628/

---

As i did not test in Opera and IE and futhermore, FF displays a warning, i do not know, if that is the best approach with `target=_blank`. Any other ideas for solving this issue?
