### PR TITLE
Add a separator to H2-Headers in Wiki

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/wiki.less
+++ b/inyoka_theme_ubuntuusers/static/style/wiki.less
@@ -25,6 +25,9 @@ h1.pagetitle {
     text-decoration: none;
   }
 }
+h2 {
+  border-bottom: 1px solid #e0c99d;
+}
 h2, h3, h4 {
   margin-top: 1.4em;
 }


### PR DESCRIPTION
This PR adds a separator to H2-Headers in wiki.

Wished in: https://forum.ubuntuusers.de/topic/design-ueberschriften/
