### PR TITLE
Show the note associated to a suggestion

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/ikhaya/suggestions.html
+++ b/inyoka_theme_ubuntuusers/templates/ikhaya/suggestions.html
@@ -60,7 +60,7 @@
             <h3 class="title">{{ suggestion.title|e }}</h3>
             <div class="intro">{{ suggestion.intro_rendered }}</div>
             <div class="text">{{ suggestion.text_rendered }}</div>
-            {%- if suggestion.rendered_notes %}
+            {% if suggestion.notes_rendered %}
               <hr />
               <div>{{ suggestion.notes_rendered }}</div>
             {%- endif %}


### PR DESCRIPTION
Currently it is not displayed anymore (as the if always fails)
"rendered_notes" were changed to "notes_rendered" with the  redis-integration.
