### PR TITLE
Increased minimum Size of Tag in TagCloud

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/wiki.less
+++ b/inyoka_theme_ubuntuusers/static/style/wiki.less
@@ -216,7 +216,7 @@ div.conflict {
 .tagclasses(@counter) when (@counter > 0) {
   .tagclasses((@counter - 1));    // next iteration
   .tag-@{counter} {
-    font-size: 85+@counter*15%;
+    font-size: 140+@counter*10%;
   }
 }
 .tagclasses(10);


### PR DESCRIPTION
I think, the smallest entries in the tag cloud are too small (http://wiki.testing.ubuntuusers.de/wiki/tags). So I increased their size from 100 to 150%. The biggest entries have changed from 235 to 240%.
