### PR TITLE
'current revision' -> 'revison #foo'

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/wiki/action_diff.html
+++ b/inyoka_theme_ubuntuusers/templates/wiki/action_diff.html
@@ -49,7 +49,7 @@
       </p>
       {{ diff.render() }}
     {%- endif %}
-    <h1 class="pagetitle">{% trans %}Current revision{% endtrans %}</h1>
+    <h1 class="pagetitle">{% trans new_rev=diff.new_rev.change_date|datetime %} Revision {{ new_rev }} {% endtrans %} </h1>
     {{ diff.new_rev.rendered_text }}
   </div>
 {% endblock %}


### PR DESCRIPTION
Fixes http://trac.inyokaproject.org/ticket/883.

The wiki diff does not show the current version but the latest one of the compared versions.
