### PR TITLE
Fix recentchanges template

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/wiki/recentchanges.html
+++ b/inyoka_theme_ubuntuusers/templates/wiki/recentchanges.html
@@ -32,7 +32,7 @@
       {{ recentchanges[day][page][0]['time'] }}
       {%- endif %}
       </td>
-      <td><a href="{{ page|url|e }}">{{ page|e }}</a> (<a href="{{ page|url('log')|e }}">{{ recentchanges[day][page]|length }}x</a>)</td>
+      <td><a href="{{ href('wiki', page)|e }}">{{ page|e }}</a> (<a href="{{ href('wiki', page, 'a', 'log')|e }}">{{ recentchanges[day][page]|length }}x</a>)</td>
       <td class="note">
        <ul class="note_list">
        {%- for change in recentchanges[day][page] %}


### PR DESCRIPTION
The way recentchanges works doesn't support |url filters in the template, so
I revert the changes to `wiki/recentchanges.html` from f62ef60.
