### PR TITLE
Use absolute URL to wiki tags

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/wiki/action_show.html
+++ b/inyoka_theme_ubuntuusers/templates/wiki/action_show.html
@@ -39,7 +39,7 @@
         At this page the following tags have been assigned:
       {%- endtrans %}
       {% for tag in tags -%}
-        <a href="wiki/tags/{{ tag|e }}">{{ tag|e }}</a>
+        <a href="{{ href('wiki', 'wiki', 'tags', tag|e) }}">{{ tag|e }}</a>
         {%- if not loop.last %}, {% endif %}
       {%- endfor %}
     {%- endif %}


### PR DESCRIPTION
on subpages like "Unity/Desktop" a taglink for a tag named "Desktop" was "wiki.<domain>/Unity/wiki/tags/Desktop". Instead it should be "wiki.<domain>/wiki/tags/Desktop" (no "Unity" before "wiki/tags") This was caused by the usage of relative links.

see https://forum.ubuntuusers.de/post/7925383/

I was unable to test it in perfection, as my local instance didn't want to display new tags in articles…
