### PR TITLE
Notifications: Remove old-style urls

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/mails/page_edited.jabber.txt
+++ b/inyoka_theme_ubuntuusers/templates/mails/page_edited.jabber.txt
@@ -2,5 +2,4 @@ Der Benutzer „{{ rev_username }}“ hat die Wiki-Seite „{{ page_title }}“ 
 {%- if rev_note %}
 Änderungsnotiz: „{{ rev_note }}“
 {%- endif %}
-Unterschiede: {{ href('wiki', page_name, action='diff', new_rev=rev_id, rev=old_rev_id) }}
-Alle aktuellen Änderungen: {{ href('wiki', page_name, action='diff', rev=old_rev_id) }}
+Unterschiede: {{ diff_url }}

--- a/inyoka_theme_ubuntuusers/templates/mails/page_edited.txt
+++ b/inyoka_theme_ubuntuusers/templates/mails/page_edited.txt
@@ -4,7 +4,6 @@ der Benutzer „{{ rev_username }}“ hat die Wiki-Seite „{{ page_name }}“ v
 {% if rev_note %}
 Es wurde folgende Änderungsnotiz angegeben: „{{ rev_note }}“
 {% endif %}
-Du kannst dir die Änderungen hier ansehen: {{ href('wiki', page_name, action='diff', new_rev=rev_id, rev=old_rev_id) }}
-Oder dir hier alle Änderungen seit deinem letzten Besuch anzeigen lassen: {{ href('wiki', page_name, action='diff', rev=old_rev_id) }}
+Du kannst dir die Änderungen hier ansehen: {{ diff_url }}
 
-Falls du bei Veränderungen an dieser Seite in Zukunft nicht mehr benachrichtigt werden willst, so kannst du das hier deaktivieren: {{ href('wiki', page_name, action='unsubscribe') }}
+Falls du bei Veränderungen an dieser Seite in Zukunft nicht mehr benachrichtigt werden willst, so kannst du das hier deaktivieren: {{ unsubscribe_url }}


### PR DESCRIPTION
- urls now created in inyoka.wiki.notifications
- diff for one revision is no longer available → removed
