### PR TITLE
Fixes for new Breadcrumb

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/overall.m.html
+++ b/inyoka_theme_ubuntuusers/templates/overall.m.html
@@ -9,7 +9,7 @@
     :copyright: (c) 2007-2016 by the Inyoka Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 #}
-{% import macros.html as macros %}
+{% import 'macros.html' as macros %}
 {% set BREADCRUMBS = BREADCRUMBS|default([]) %}
 
 <!DOCTYPE html>

--- a/inyoka_theme_ubuntuusers/templates/portal/about_inyoka.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/about_inyoka.html
@@ -9,6 +9,9 @@
 #}
 
 {%- extends 'portal/overall.html' %}
+
+{% set BREADCRUMBS = [(_('Inyoka'), href('portal', 'inyoka'))] + BREADCRUMBS|d([]) %}
+
 {% macro badge(link, alt, img) -%}
   <a href="{{ link|e }}"><img src="{{ href('static',
     'img/badges/' + img)|e }}" alt="{{ alt|e }}" /></a>

--- a/inyoka_theme_ubuntuusers/templates/portal/feedselector.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/feedselector.html
@@ -11,6 +11,8 @@
 {% extends 'portal/overall.html' %}
 {% set styles = ['feedselector'] %}
 
+{% set BREADCRUMBS = [(_('Feeds'), href('portal', 'feeds'))] + BREADCRUMBS|d([]) %}
+
 {% block portal_content %}
   <h3>Feed generieren</h3>
   {%- if not app %}

--- a/inyoka_theme_ubuntuusers/templates/portal/index.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/index.html
@@ -10,7 +10,6 @@
     :license: BSD, see LICENSE for more details.
 #}
 {%- extends 'portal/overall.html' %}
-{% set BREADCRUMBS = [(_('Portal'), href('portal'))] + BREADCRUMBS|d([]) %}
 
 {% block pre_navigation %}
   {%- if countdown_active -%}

--- a/inyoka_theme_ubuntuusers/templates/portal/overall.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/overall.html
@@ -16,6 +16,8 @@
 {% endif %}
 {% set styles = ['portal'] + styles|default([]) %}
 
+{% set BREADCRUMBS = [(_('Portal'), href('portal'))] + BREADCRUMBS|d([]) %}
+
 {% macro feed_button(link) -%}
   <a href="{{ link }}" class="feed_icon"><img src="{{ href('static', 'img', 'feed.png') }}" alt="Newsfeed" /></a>
 {%- endmacro %}


### PR DESCRIPTION
- resolved small syntax error in mobile overall.m.html (mind the ')
- 'Portal' is now added to the breadcrumbs in portal/overall.html
  instead of portal/index.html

Tracebacks were listed in sentry. Alternatively, see https://gist.github.com/encbladexp/7a10154e0fef1f5e95e0. I couldn't test the 404-page (last trace) on my development server. However, it should be fixed, too, as the problem was at the same line as for the 2nd trace.
