### PR TITLE
Avoid showing a users Userpage if the user itself is blocked or deleted.

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/portal/profile.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/profile.html
@@ -145,6 +145,6 @@
         </td>
       </tr>
     </table>
+    {{ user.rendered_userpage }}
   {% endif %}
-  {{ user.rendered_userpage }}
 {% endblock %}


### PR DESCRIPTION
If a blocked or deleted User has an Userpage, we show this page. There is now reason to do this, and we should avoid this and hide Userpage-Spam too.
