### PR TITLE
Fixed wide tables in wiki

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/markup.less
+++ b/inyoka_theme_ubuntuusers/static/style/markup.less
@@ -72,6 +72,9 @@ a.interwiki-wikipedia_en {
   padding-left: 20px;
 }
 
+#page table {
+  width: auto; // override behaviour of main.css for wiki & ikhaya
+}
 #page table td, #page table th {
   border-width: 1px;
 }


### PR DESCRIPTION
see https://forum.ubuntuusers.de/topic/bildermakro-funktioniert-nicht-mit-meinem-chro/
introduced via https://github.com/chris34/theme-ubuntuusers/commit/d8111e65a555c91039c865ab4798f80ee6a4ba6f
