### PR TITLE
Updated jshint to ~1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-cli": "^0.1.13",
     "grunt-contrib-compress": "^0.14.0",
     "grunt-contrib-concat": "~0.4.0",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "~1.0.0",
     "grunt-contrib-less": "^1.0.0",
     "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-uglify": "~0.5.0",


### PR DESCRIPTION
Resolved error-message

```
 Warning: Path must be a string. Received null Use --force to continue.
```

of grunt-jshint

needs an `npm install`
