### PR TITLE
Workarounded failing Jenkins-build (virtualenv)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ node {
     checkout scm
 
     stage 'Build virtualenv'
-    sh '''virtualenv venv
+    sh '''virtualenv --no-download venv
     . ./venv/bin/activate
     # Workaround for pip, because it will hang forever when not updated and using the cache.
     pip install --upgrade pip --no-cache-dir


### PR DESCRIPTION
Fixes issue with virtualenv/pip where creating a venv just hangs
