### PR TITLE
Add version-parameter to JS/CSS-files to flush browser-caches

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/overall.html
+++ b/inyoka_theme_ubuntuusers/templates/overall.html
@@ -31,14 +31,14 @@
       {#- This way the local stylesheets can override styles without problems. #}
       {% set styles = ['main', 'markup'] + styles|default([]) %}
       {% for style in styles %}
-        <link rel="stylesheet" type="text/css" href="{{ href('static', 'style', '%s.css'|format(style)) }}" />
+        <link rel="stylesheet" type="text/css" href="{{ href('static', 'style', '%s.css'|format(style), v=INYOKA_VERSION) }}" />
       {% endfor %}
 
-      <link rel="stylesheet" type="text/css" href="{{ href('portal', 'markup.css') }}" />
-      <link rel="stylesheet" type="text/css" href="{{ href('static', 'style', 'print.css') }}" media="print" />
+      <link rel="stylesheet" type="text/css" href="{{ href('portal', 'markup.css', v=INYOKA_VERSION) }}" />
+      <link rel="stylesheet" type="text/css" href="{{ href('static', 'style', 'print.css', v=INYOKA_VERSION) }}" media="print" />
 
       {% if special_day_css %}
-        <link rel="stylesheet" type="text/css" href="{{ href('static', 'style', 'special_day', special_day_css) }}" />
+        <link rel="stylesheet" type="text/css" href="{{ href('static', 'style', 'special_day', special_day_css, v=INYOKA_VERSION) }}" />
       {% endif %}
 
       {% for title, url in feeds %}
@@ -270,7 +270,7 @@
     <div style="clear: both;"></div>
    </div>
 
-    <script type="text/javascript" src="{{ href('portal', 'jsi18n') }}"></script>
+    <script type="text/javascript" src="{{ href('portal', 'jsi18n', v=INYOKA_VERSION) }}"></script>
     <script type="text/javascript">
     /*<![CDATA[*/
       var
@@ -287,7 +287,7 @@
      {% if SETTINGS.DEBUG %}
        <script type="text/javascript" src="{{ href('static', 'js/%s.js'|format(script)) }}"></script>
      {% else %}
-       <script type="text/javascript" src="{{ href('static', 'js/%s.min.js'|format(script)) }}"></script>
+       <script type="text/javascript" src="{{ href('static', 'js/%s.min.js'|format(script), v=INYOKA_VERSION) }}"></script>
      {% endif %}
    {% endfor %}
 


### PR DESCRIPTION
All JS- & CSS-files get an GET-Parameter with the current Inyoka
version. After a theme-deployment, these static files will be reloaded,
as all have new URLs for the browser. Thus, (most) users wont need to manually flush
their browser-caches anymore. ("Most" as some proxies ignore GET-Parameters and
will still server the old content)

Our static-server (Nginx) needs no changes, as it currently ignores
GET-Parameters. For example https://static-cdn.ubuntu-de.org/style/portal.css
serves the same content as https://static-cdn.ubuntu-de.org/style/portal.css?v=1
