### PR TITLE
Make delete paste Link visible again if user has permission. Fixes #656

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/pastebin/display.html
+++ b/inyoka_theme_ubuntuusers/templates/pastebin/display.html
@@ -32,7 +32,7 @@
     <dd class="paste_actions">
       <ul>
         <li><a href="{{ entry|url('raw') }}">{% trans %}Display entry as raw text{% endtrans %}</a></li>
-        {%- if USER.has_perms('pastebin.delete_entry') %}
+        {%- if USER.has_perm('pastebin.delete_entry') %}
           <li><a href="{{ entry|url('delete') }}" class="admin_link">{% trans %}Delete entry{% endtrans %}</a></li>
       {%- endif %}
       </ul>


### PR DESCRIPTION
has_perms() and has_perm()… it could be so simple ;)