### PR TITLE
Fixes inyokaproject/inyoka#668 Show the delete button if you have the…

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/forum/topic.html
+++ b/inyoka_theme_ubuntuusers/templates/forum/topic.html
@@ -82,7 +82,7 @@
       {%- if topic.hidden %}
         <a href="{{ topic|url('restore') }}"
            class="action action_restore admin_link">{% trans %}Restore{% endtrans %}</a> |
-        {%- if USER.has_perm('forum.delete_topic_forum') %}
+        {%- if USER.has_perm('forum.delete_topic_forum', forum) %}
         <a href="{{ topic|url('delete') }}"
            class="action action_delete admin_link">{% trans %}Delete{% endtrans %}</a> |
         {%- endif %}


### PR DESCRIPTION
… perm

Delete permission is a forum based permission and not a globale one.
Therefore the forum needs to be transmitted for the visiblity check.