### PR TITLE
Include the raven userfeedback prompt to the 500 exception page

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/errors/500.html
+++ b/inyoka_theme_ubuntuusers/templates/errors/500.html
@@ -19,5 +19,16 @@
     <p>
       {% trans %}An internal error occurred. The administration was already notified.{% endtrans %}
     </p>
+
+  {% if dsn and request.sentry and request.sentry.id %}
+    <script src="https://cdn.ravenjs.com/2.3.0/raven.min.js"></script>
+    <script>
+      Raven.showReportDialog({
+        eventId: '{{ request.sentry.id }}',
+        dsn: '{{ dsn }}'
+      });
+    </script>
+  {% endif %}
+
   </body>
 </html>


### PR DESCRIPTION
If the public dsn is defined, it will ask for user feedback at a 500
exception.

This is the ui part for inyokaproject/inyoka#781.