### PR TITLE
Highlight categories in forum permission view

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/main.less
+++ b/inyoka_theme_ubuntuusers/static/style/main.less
@@ -368,6 +368,9 @@ table {
     }
   }
 }
+table tr.head td {
+    background-color: lighten(#f4e7ce, 5%);
+}
 table tr.head th,table thead th {
   .table-header-gradient;
   padding: 0.3em 0;

--- a/inyoka_theme_ubuntuusers/templates/portal/group_edit_forum_permissions.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/group_edit_forum_permissions.html
@@ -42,7 +42,7 @@
         </tr>
 
         {% for field in form %}
-          <tr>
+          <tr {% if field.field.is_category %}class="head"{% endif %}>
             {{ field.errors }}
             <th>
               {{ field.label }}


### PR DESCRIPTION
This change is part of inyokaproject/inyoka#861 and improves the
readability of the forum permission view with an highlight of
categories.

This can only be merged if inyokaproject/inyoka#867 is merged.