### PR TITLE
Workaround for article ids in planet with jinja2.9

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/planet/index.html
+++ b/inyoka_theme_ubuntuusers/templates/planet/index.html
@@ -31,13 +31,18 @@
     {%- endif %}
 
     <div class="articles">
-      {% set article_index = 0 %}
+      {% set article_index = [0] %}
       {%- for day in days %}
         <div class="day">
           <h2>{{ day.date|naturalday }}</h2>
           {% set dayloop = loop %}
           {% for article in day.articles %}
-            <div class="article admin_link_hover" id="article_{{ article_index + loop.index0 }}">
+            {% set current_article_id = article_index[0] + loop.index0 %}
+            {% if loop.last %}
+              {% do article_index.pop() %}
+              {% do article_index.append(current_article_id + 1) %}
+            {% endif %}
+            <div class="article admin_link_hover" id="article_{{ current_article_id }}">
               <div class="head">
                 <a href="{{ article.blog|url|e }}">
                   <img
@@ -49,15 +54,15 @@
                   {{ article.pub_date|datetime }}
                   <div class="easy-navigation">
                     {%- if not (dayloop.first and loop.first) %}
-                      <a href="#article_{{ article_index + loop.index0 - 1 }}">{% trans %}« Previous{% endtrans %}</a>
+                      <a href="#article_{{ current_article_id - 1 }}">{% trans %}« Previous{% endtrans %}</a>
                     {%- endif %}
                     {%- if not (dayloop.last and loop.last) %}
-                      <a href="#article_{{ article_index + loop.index0 + 1 }}">{% trans %}Next »{% endtrans %}</a>
+                      <a href="#article_{{ current_article_id + 1 }}">{% trans %}Next »{% endtrans %}</a>
                     {%- endif %}
                   </div>
                   <h3>
                     <a href="{{ article|url|e }}">{{ article.title }}</a>
-                    <a class="headerlink" href="#article_{{ article_index + loop.index0 }}">¶</a>
+                    <a class="headerlink" href="#article_{{ current_article_id }}">¶</a>
                   </h3>
               </div>
               </div>
@@ -83,7 +88,6 @@
               </div>
             </div>
           {%- endfor %}
-          {% set article_index = article_index + day.articles|length %}
         </div>
       {%- endfor %}
     </div>


### PR DESCRIPTION
With jinja 2.9 a scope-bug of `set` was fixed. Thus, the variable `article_index`
was not updated in line 86 anymore. As a consequence every article id of a new
day started with `article_index = 0` again.

As a workaround the index is now saved in a list with only one elemnt, because
the scoping of `do` still works as expected here.

After the release of jinja 2.10 a rewrite with the new `namespace`-object would
be the best solution.
See http://jinja.pocoo.org/docs/dev/templates/#assignments

Reported via https://forum.ubuntuusers.de/topic/trac-nicht-erreichbar/#post-8892015