### PR TITLE
WikiEditor: Fix link to documentation of table-syntax

### DIFF
--- a/inyoka_theme_ubuntuusers/static/js/WikiEditor.js
+++ b/inyoka_theme_ubuntuusers/static/js/WikiEditor.js
@@ -279,7 +279,7 @@
         item('{{{#!vorlage Warnung\n%s\n}}}', 'Warnung'),
         item('{{{#!vorlage Experten\n%s\n}}}', 'Experten-Info'),
         item('[[Vorlage(Tasten, %s)]]', 'Taste'),
-        item('{{{#!vorlage Tabelle\n{S/[:Wiki/Syntax/Tabellen:]}\n}}}', 'Tabelle')
+        item('{{{#!vorlage Tabelle\n{S/[:Wiki/Tabellen:]}\n}}}', 'Tabelle')
       ],
       function(evt) {
         if (evt.target.value.length > 0)


### PR DESCRIPTION
reported via https://forum.ubuntuusers.de/topic/wiki-editor-fehlerhafte-verlinkung-im-menue-te