### PR TITLE
Remove Ubuntu Tour

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/portal/overall.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/overall.html
@@ -35,7 +35,6 @@
       <li><a href="{{ href('wiki', 'Ubuntu FAQ') }}">{% trans %}FAQ{% endtrans %}</a></li>
       <li><a href="{{ href('wiki', 'Downloads') }}">{% trans %}Downloads{% endtrans %}</a></li>
       <li><a href="http://verein.ubuntu-de.org/" class="extlink">Verein</a></li>
-      <li><a href="http://tour.ubuntuusers.de/" class="extlink">Ubuntu Tour</a></li>
       <li><a href="{{ href('portal', 'calendar') }}">{% trans %}Calendar{% endtrans %}</a></li>
     </ul>
     <h3 class="navi_ubuntuusers"><a href="{{ href('portal') }}">{{ SETTINGS.BASE_DOMAIN_NAME }}</a></h3>


### PR DESCRIPTION
remove Ubuntu Tour, cause it is old and Ubuntu changed his new version to Gnome3 and is not using by default unity any more.