### PR TITLE
Parse the time in recentchanges localized

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/wiki/recentchanges.html
+++ b/inyoka_theme_ubuntuusers/templates/wiki/recentchanges.html
@@ -30,10 +30,10 @@
           {% for page in recentchanges[day].keys() %}
             <tr>
               <td>
-              {{ recentchanges[day][page][-1]['time'] }}
+              {{ recentchanges[day][page][-1]['change_date']|timetz }}
               {% if recentchanges[day][page]|length > 1 %}
               -
-              {{ recentchanges[day][page][0]['time'] }}
+              {{ recentchanges[day][page][0]['change_date']|timetz}}
               {% endif %}
               </td>
               <td class="pagelink">


### PR DESCRIPTION
The time was displayed in UTC and in a to detailed format.

The backend part for this change is inyokaproject/inyoka#957

Fixes inyokaproject/inyoka#950
Fixes inyokaproject/inyoka#951