### PR TITLE
Make tables in wiki horizontal scrollable

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/wiki.less
+++ b/inyoka_theme_ubuntuusers/static/style/wiki.less
@@ -11,9 +11,11 @@
 
 @import 'fonts.less';
 
-div.content {
-  padding-left: 15px;
-  overflow-y:hidden;
+table:not([class]) {
+  max-width: 100%;
+  display: inline-block;
+  overflow-x: auto;
+  border: none;
 }
 
 .navi_sidebar {


### PR DESCRIPTION
Only apply the new behaviour in the wiki and for tables without classes.
Thus, legacy behaviour should be ok. Even though tables with inline-styles like
`tablestyle="width: 50%;"` have changed behaviour (the % are now relative
to the content-container instead of the screen width).

Discussion: https://forum.ubuntuusers.de/topic/wer-hat-den-scrollbalken-geklaut