### PR TITLE
Drop `Was ist Ubuntu?` link from portal sidebar

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/portal/overall.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/overall.html
@@ -31,7 +31,6 @@
   <div class="container">
     <h3 class="navi_ubuntu"><a href="http://www.ubuntu.com" class="extlink">Ubuntu</a></h3>
     <ul>
-      <li><a href="{{ href('wiki', 'Was_ist_Ubuntu') }}">Was ist Ubuntu?</a></li>
       <li><a href="{{ href('wiki', 'Ubuntu FAQ') }}">{% trans %}FAQ{% endtrans %}</a></li>
       <li><a href="{{ href('wiki', 'Downloads') }}">{% trans %}Downloads{% endtrans %}</a></li>
       <li><a href="http://verein.ubuntu-de.org/" class="extlink">Verein</a></li>


### PR DESCRIPTION
The link now refers to `href('wiki', 'Ubuntu FAQ')` and thus is a duplicate.

see https://forum.ubuntuusers.de/topic/portal-2-links-aendern-und-1-link-dazu