### PR TITLE
Replace links to Forenregeln

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/forum/report.html
+++ b/inyoka_theme_ubuntuusers/templates/forum/report.html
@@ -18,7 +18,7 @@
     {{ csrf_token() }}
     <h2>{% trans topic=topic.title|e %}Report topic “{{ topic }}”{% endtrans %}</h2>
     <p>
-      {%- trans link=href('wiki', 'ubuntuusers/Moderatoren/Forenregeln') -%}
+      {%- trans link=href('wiki', 'ubuntuusers/Moderatoren/Portalregeln') -%}
         Here you can report a topic to the moderators if it is against our <a href="{{ link }}">rules</a>. Please add a short explanation:
       {%- endtrans -%}
     </p>

--- a/inyoka_theme_ubuntuusers/templates/forum/report.m.html
+++ b/inyoka_theme_ubuntuusers/templates/forum/report.m.html
@@ -17,7 +17,7 @@
     {{ csrf_token() }}
     <h2>{% trans topic=topic.title|e %}Report topic “{{ topic }}”{% endtrans %}</h2>
     <p>
-      {%- trans link=href('wiki', 'ubuntuusers/Moderatoren/Forenregeln') -%}
+      {%- trans link=href('wiki', 'ubuntuusers/Moderatoren/Portalregeln') -%}
         Here you can report a topic to the moderators if it is against our <a href="{{ link }}">rules</a>. Please add a short explanation:
       {%- endtrans -%}
     </p>

--- a/inyoka_theme_ubuntuusers/templates/portal/register.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/register.html
@@ -23,7 +23,7 @@
                             'email'], inline=true)}}
       <dt>Nutzungshinweise:</dt>
       {# include the agreement letter #}
-      <dd>{{ form.terms_of_usage }} <label for="id_terms_of_usage">Ich bestätige den <a href="{{ href('portal', 'lizenz') }}">Lizenztext</a> gelesen zu haben und erkläre mich mit der Veröffentlichung unter dieser Lizenz einverstanden.<br />Durch das Abschließen der Registrierung stimme ich den <a href="{{ href('portal', 'nutzungsbedingungen') }}">Nutzungsbedingungen</a> und <a href="//wiki.ubuntuusers.de/ubuntuusers/Moderatoren/Forenregeln">Forenregeln</a> ebenfalls zu.</label><br />
+      <dd>{{ form.terms_of_usage }} <label for="id_terms_of_usage">Ich bestätige den <a href="{{ href('portal', 'lizenz') }}">Lizenztext</a> gelesen zu haben und erkläre mich mit der Veröffentlichung unter dieser Lizenz einverstanden.<br />Durch das Abschließen der Registrierung stimme ich den <a href="{{ href('portal', 'nutzungsbedingungen') }}">Nutzungsbedingungen</a> und <a href="//wiki.ubuntuusers.de/ubuntuusers/Moderatoren/Portalregeln/">Portalregeln/</a> ebenfalls zu.</label><br />
       {{ form.errors.terms_of_usage }}
       <p>Um möglichst gute Hilfe erhalten, beachte bitte folgende Punkte:</p>
       <ul>

--- a/inyoka_theme_ubuntuusers/templates/portal/register.m.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/register.m.html
@@ -23,7 +23,7 @@
                             'email'], inline=true)}}
       <dt>Nutzungshinweise:</dt>
       {# include the agreement letter #}
-      <dd>{{ form.terms_of_usage }} <label for="id_terms_of_usage">Ich bestätige den <a href="{{ href('portal', 'lizenz') }}">Lizenztext</a> gelesen zu haben und erkläre mich mit der Veröffentlichung unter dieser Lizenz einverstanden.<br />Durch das Abschließen der Registrierung stimme ich den <a href="{{ href('portal', 'nutzungsbedingungen') }}">Nutzungsbedingungen</a> und <a href="//wiki.ubuntuusers.de/ubuntuusers/Moderatoren/Forenregeln">Forenregeln</a> ebenfalls zu.</label><br />
+      <dd>{{ form.terms_of_usage }} <label for="id_terms_of_usage">Ich bestätige den <a href="{{ href('portal', 'lizenz') }}">Lizenztext</a> gelesen zu haben und erkläre mich mit der Veröffentlichung unter dieser Lizenz einverstanden.<br />Durch das Abschließen der Registrierung stimme ich den <a href="{{ href('portal', 'nutzungsbedingungen') }}">Nutzungsbedingungen</a> und <a href="//wiki.ubuntuusers.de/ubuntuusers/Moderatoren/Portalregeln/">Portalregeln/</a> ebenfalls zu.</label><br />
       {{ form.errors.terms_of_usage }}</dd>
       <dd>{{ form.hidden_captcha }}</dd>
       <dd>{{ form.errors.hidden_captcha }}</dd>


### PR DESCRIPTION
They redirect to the Portalregeln since a while. Replace the last
occurrences in the HTML.