### PR TITLE
Fixed typo in translation for 'Rename to:'

### DIFF
--- a/inyoka_theme_ubuntuusers/locale/de_DE/LC_MESSAGES/django.po
+++ b/inyoka_theme_ubuntuusers/locale/de_DE/LC_MESSAGES/django.po
@@ -1323,7 +1323,7 @@ msgid "Rename page"
 msgstr "Seite umbenennen"
 
 msgid "Rename to:"
-msgstr "Umbennen zu:"
+msgstr "Umbenennen zu:"
 
 msgid "Replies"
 msgstr "Antworten"


### PR DESCRIPTION
reported via https://forum.ubuntuusers.de/topic/rechtschreibfehler-3/