### PR TITLE
Remove autocompletion for topic in splittopic

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/forum/splittopic.html
+++ b/inyoka_theme_ubuntuusers/templates/forum/splittopic.html
@@ -121,15 +121,3 @@
     <input type="submit" name="split" value="{% trans %}Split posts{% endtrans %}" />
   </form>
 {% endblock %}
-
-{% block additional_scripts %}
-  {{ super() }}
-  <script type="text/javascript">
-    /* <![CDATA[ */
-    (function () {
-      $('#id_topic').autocomplete('/?__service__=forum.get_topic_autocompletion', {
-        delay: 40, cacheLength: 10});
-    })();
-    /* ]]> */
-  </script>
-{% endblock %}


### PR DESCRIPTION
It was preceived as annoying from team members. One reason was, that more
posts were added to the wrong topic.