### PR TITLE
Wiki attachments: Remove whitespace

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/wiki/action_attach.html
+++ b/inyoka_theme_ubuntuusers/templates/wiki/action_attach.html
@@ -30,7 +30,7 @@
         {{ form.attachment }}</p>
       <p><label for="id_filename">{% trans %}Rename to:{% endtrans %}</label>
         {{ form.filename }}</p>
-      <p><label for="id_text">{% trans %}Description:{% endtrans %}</label><br style="clear: both" /></p>
+      <p><label for="id_text">{% trans %}Description:{% endtrans %}</label><br /></p>
         <p>{{ form.text }}</p>
       <p><label for="id_note">{% trans %}Edit summary:{% endtrans %}</label>
         {{ form.note }}</p>

--- a/inyoka_theme_ubuntuusers/templates/wiki/action_attach_edit.html
+++ b/inyoka_theme_ubuntuusers/templates/wiki/action_attach_edit.html
@@ -29,7 +29,7 @@
       </p>
       <p>
         <label for="id_text">{% trans %}Description:{% endtrans %}</label>
-        <br style="clear:both" />
+        <br />
       </p>
       <p>{{ form.text }}</p>
       <p>


### PR DESCRIPTION
The inline style `clear: both` caused that the following tags were displayed
after the end of the left sidebar. Thus, causing much unwantead whitespace.