### PR TITLE
Fix position of left floating images in wiki

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/markup.less
+++ b/inyoka_theme_ubuntuusers/static/style/markup.less
@@ -89,7 +89,6 @@ span.underline {
   clear: right;
 }
 .image-left {
-  clear: left;
   float: left;
 }
 .image-center {


### PR DESCRIPTION
reported via
https://forum.ubuntuusers.de/topic/delta-beim-wiki-zwischen-vorschau-und-gespeich/
(see screenshots in the first post)