### PR TITLE
editor: add empty quote if no text selected

### DIFF
--- a/inyoka_theme_ubuntuusers/static/js/WikiEditor.js
+++ b/inyoka_theme_ubuntuusers/static/js/WikiEditor.js
@@ -186,6 +186,7 @@
       var selection = this.getSelection();
       if (selection.length)
         this.setSelection(this.quoteText(selection));
+      else this.insertTag('> %s', 'Zitierter Text');
     }, ['forum'], help("Auswahl zitieren")),
     button('picture', 'Bild', insert('[[Bild(%s)]]', 'Bildname'),
            ['wiki'], help("[[Bild(Bildname)]]")),


### PR DESCRIPTION
Same behavior as for lists
Quotation button did only have an effect with some text selected previously