### PR TITLE
Fixed wide text-inputs with Emojis in Firefox 64

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/ikhaya.less
+++ b/inyoka_theme_ubuntuusers/static/style/ikhaya.less
@@ -267,3 +267,8 @@ div.preview_wrapper {
     padding-bottom: 10px;
   }
 }
+
+/* fix too wide text-inputs with Emojis in Firefox 64 */
+input[type="text"] {
+    width: 100%;
+}


### PR DESCRIPTION
This only was seen in Ikhaya, so it is only added to `ikhaya.less` for now.

Only tested it quickly via the developer tools. Feel free to test it locally.