### PR TITLE
New Report: Show reporter instead of current user

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/mails/new_reported_topic.jabber.txt
+++ b/inyoka_theme_ubuntuusers/templates/mails/new_reported_topic.jabber.txt
@@ -1,3 +1,3 @@
-Der Benutzer {{ USER.username }} hat das Thema „{{ topic.title }}“ im Forum „{{ topic.forum }}“ ( {{ topic|url }} ) gemeldet.
+Der Benutzer {{ topic.reporter }} hat das Thema „{{ topic.title }}“ im Forum „{{ topic.forum }}“ ( {{ topic|url }} ) gemeldet.
     {{ text|wordwrap(75, false)|indent(4) }}
 Übersicht über alle gemeldeten Themen: {{ href('forum', 'reported_topics') }}

--- a/inyoka_theme_ubuntuusers/templates/mails/new_reported_topic.txt
+++ b/inyoka_theme_ubuntuusers/templates/mails/new_reported_topic.txt
@@ -1,6 +1,6 @@
 Hallo,
 
-der Benutzer {{ USER.username }} hat das Thema „{{ topic.title }}“ im Forum „{{ topic.forum }}“ ( {{ topic|url }} ) gemeldet.
+der Benutzer {{ topic.reporter }} hat das Thema „{{ topic.title }}“ im Forum „{{ topic.forum }}“ ( {{ topic|url }} ) gemeldet.
 
     {{ text|wordwrap(75, false)|indent(4) }}
 


### PR DESCRIPTION
Thus, after merging https://github.com/inyokaproject/inyoka/pull/1033 the system user will be displayed as reporter.

Reported via https://github.com/inyokaproject/inyoka/pull/1033#issuecomment-496636370