### PR TITLE
Fix hex color for new less version

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/markup.less
+++ b/inyoka_theme_ubuntuusers/static/style/markup.less
@@ -464,7 +464,7 @@ tr.edu {
     font-weight: bold;
   }
   &-normal {
-    background: #e1dac6f;
+    background: #e1dac6;
     color: @white;
   }
   &-highlight {


### PR DESCRIPTION
With less version 3.10.1 color strings seem to be validated. There was
an invalid string, which caused that LESS was not converted to CSS and
thus, the complete CI will not run anymore.