### PR TITLE
Ikhaya, comments: Always use full width

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/ikhaya.less
+++ b/inyoka_theme_ubuntuusers/static/style/ikhaya.less
@@ -96,6 +96,10 @@ a.show_comments,a.hide_comments {
 a.show_comments:hover,a.hide_comments:hover {
   text-decoration: underline;
 }
+
+#page table.comments {
+  width: 100%; /* overwrite `#page table` from markup.less */
+}
 table.comments {
   table-layout: fixed;
   margin: 0;


### PR DESCRIPTION
After https://github.com/inyokaproject/theme-ubuntuusers/commit/17ac5190f27195b47607fd2ad64ce654ae644235
the comment table used only the width it needed. However, especially on wide screens
with short sentences in the comments, the table seemed to be too small.

Prevents something like
https://media-cdn.ubuntu-de.org/forum/attachments/41/33/9093870-Kommentare_ikhaya.png