### PR TITLE
Groupselector: Drop second scrollbar

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/portal.less
+++ b/inyoka_theme_ubuntuusers/static/style/portal.less
@@ -22,13 +22,6 @@ form.usercp_form {
   ul {
     list-style: none;
   }
-
-  #portal-user-groupselector{
-    max-height: 800px;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-
   > * {
     margin-top: 1em;
   }


### PR DESCRIPTION
Removes the scrollbar marked with green color:
![Bildschirmfoto von 2019-08-29 18-24-54](https://user-images.githubusercontent.com/2538080/63967355-8a458980-ca9d-11e9-9b86-061dfd51299f.png)

As a result, the outer scrollbar will be possibly higher.