### PR TITLE
Wiki, attachments: prevent hidden label

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/wiki.less
+++ b/inyoka_theme_ubuntuusers/static/style/wiki.less
@@ -73,7 +73,7 @@ p.meta {
   }
   label {
     float: left;
-    width: 10em;
+    padding-right: 0.5em;
   }
   label[for="id_override"] {
     float: none;


### PR DESCRIPTION
Removed the fix width of the labels. Intead added some padding.
Now, the form fields are not in the same 'row', but readable.

see
https://media-cdn.ubuntu-de.org/forum/attachments/56/37/9099151-Anhang_hinzufugen_Anderungskommentar.png
https://forum.ubuntuusers.de/topic/fehlerhafte-verlinkung-in-paste-div-andere-feh/#post-9099151