### PR TITLE
Wiki, TOC: Display on the right side again

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/markup.less
+++ b/inyoka_theme_ubuntuusers/static/style/markup.less
@@ -210,43 +210,19 @@ div.workinprogress {
   }
 }
 .toc {
+  .top-rounded(.25em);
   padding: .5em;
-  padding-right: 9em; /* prevents brown links to overlap with brown background-image */
-
-  @border-toc: 1px solid #E9C790;
-  border-bottom: @border-toc;
-  border-top: @border-toc;
+  float: right;
+  margin: 0 0 1.5em 1.5em;
 
   background-image: url(../img/wiki/toc.png);
+  background-color: white; /* prevents that horizontal borders of other elements like headings are shown */
   background-position: top right;
   background-repeat: no-repeat;
 
-  ol {
-    /* list markers should look like 1, 1.1, 1.1.1, 2, 2.2 etc.
-       Thus, hide current list-marker and use ::before to display counter
-       ::marker is currently only supported in Firefox and partially Safari
-    */
-    counter-reset: toc-item;
-    padding-left: 0;
+  border: 0.01em solid #d7b97b;
 
-    li {
-      list-style: none;
-
-      &::before {
-        content: counters(toc-item, ".") " ";
-        counter-increment: toc-item;
-      }
-    }
-  }
-
-  > ol {
-    columns: 25ch 3; /* ideal width and maximum of columns */
-
-    > li:not(:first-child) {
-      /* separate all top level sections */
-      margin-top: 0.5em;
-    }
-  }
+  width: 40ex;
 
   .head {
     font-weight: bold;


### PR DESCRIPTION
This is more similar to a version before https://github.com/inyokaproject/theme-ubuntuusers/pull/319

see https://forum.ubuntuusers.de/topic/inhaltsverzeichnis-wiedereinsetzung-in-den-vor/