### PR TITLE
Enable smooth scrolling f.e. to target

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/main.less
+++ b/inyoka_theme_ubuntuusers/static/style/main.less
@@ -121,6 +121,15 @@
   margin: 0;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 body {
   font-family: @font-content;
   color: black;


### PR DESCRIPTION
Fragment is taken from https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior#Mind_users_with_motion_sickness
Latter also respects, if users do not whish animation (keep that in mind for tests).

Not all browsers support it (yet), but it is just a 'nice to have'.
If the CSS-rules are applied to `<body>` it did not work, too.