### PR TITLE
Make pagetitle of wiki-article black

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/wiki.less
+++ b/inyoka_theme_ubuntuusers/static/style/wiki.less
@@ -27,16 +27,6 @@ table:not([class]) {
   }
 }
 
-h1.pagetitle {
-  color: #a57205;
-  margin: 0.2em 0 0.5em 0;
-}
-h1.pagetitle {
-  a {
-    color: #b58215;
-    text-decoration: none;
-  }
-}
 h2 {
   border-bottom: 1px solid #e0c99d;
 }

--- a/inyoka_theme_ubuntuusers/templates/wiki/action_show.html
+++ b/inyoka_theme_ubuntuusers/templates/wiki/action_show.html
@@ -19,7 +19,7 @@
 {% endblock %}
 
 {% block wiki_content %}
-  <h1 class="pagetitle"><a href="{{ page|url('backlinks')|e }}">{{ page.short_title|e }}</a></h1>
+  <h1 class="pagetitle">{{ page.short_title|e }}</h1>
 
   {% if page.rev.attachment %}
     <div id="attachment">{{ page.rev.attachment.html_representation }}</div>


### PR DESCRIPTION
Thus, it is consistent with the other headings.

Also remove the not-intuitive backlink-link inside the heading.