### PR TITLE
Remove link to portal/markup.css

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/overall.html
+++ b/inyoka_theme_ubuntuusers/templates/overall.html
@@ -31,7 +31,6 @@
         <link rel="stylesheet" type="text/css" href="{{ href('static', 'style', '%s.css'|format(style), v=INYOKA_VERSION) }}" />
       {% endfor %}
 
-      <link rel="stylesheet" type="text/css" href="{{ href('portal', 'markup.css', v=INYOKA_VERSION) }}" />
       <link rel="stylesheet" type="text/css" href="{{ href('static', 'style', 'print.css', v=INYOKA_VERSION) }}" media="print" />
 
       {% if special_day_css %}


### PR DESCRIPTION
The view to edit the markup.css was already removed with https://github.com/inyokaproject/inyoka/pull/748.

So the link can be also removed. On staging this results in a 404 at the
moment.