### PR TITLE
Remove link to change styles

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/portal/overall.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/overall.html
@@ -91,9 +91,6 @@
     {%- if USER.has_perm('portal.change_storage') %}
       <li><a href="{{ href('portal', 'config') }}">{% trans %}General{% endtrans %}</a></li>
     {%- endif %}
-    {%- if USER.has_perm('portal.change_staticpage') %}
-      <li><a href="{{ href('portal', 'styles') }}">{% trans %}Stylesheets{% endtrans %}</a></li>
-    {%- endif %}
     {% if USER.has_perm('portal.change_linkmap') %}
       <li><a href="{{ href('portal', 'linkmap') }}">{% trans %}Linkmap{% endtrans %}</a></li>
     {%- endif %}


### PR DESCRIPTION
The view to edit the markup.css was already removed with https://github.com/inyokaproject/inyoka/pull/748.

So the link can be also removed. On staging this results in a 404 at the
moment.