### PR TITLE
Table of Contents: use `thin` for border thickness

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/markup.less
+++ b/inyoka_theme_ubuntuusers/static/style/markup.less
@@ -189,7 +189,7 @@ div.workinprogress {
   background-position: top right;
   background-repeat: no-repeat;
 
-  border: 0.01em solid #d7b97b;
+  border: thin solid #d7b97b;
 
   width: 40ex;
 


### PR DESCRIPTION
F.e. Chromium on some devices did not display any border before.