### PR TITLE
Ikhaya, comments: Use same target color for comment as forum-post

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/colors.less
+++ b/inyoka_theme_ubuntuusers/static/style/colors.less
@@ -73,3 +73,4 @@
 @main_background: @orange_d_medium;
 @admin_text: @orange_s_dark;
 @own-post-border: @orange_s_dark;
+@target-background: #f9f1bd;

--- a/inyoka_theme_ubuntuusers/static/style/forum.less
+++ b/inyoka_theme_ubuntuusers/static/style/forum.less
@@ -344,7 +344,7 @@ table.topic {
     }
   }
   tr:target td.post div.postinfo {
-    background-color: #f9f1bd;
+    background-color: @target-background;
   }
 }
 table.topic table td, table.topic table th {

--- a/inyoka_theme_ubuntuusers/static/style/ikhaya.less
+++ b/inyoka_theme_ubuntuusers/static/style/ikhaya.less
@@ -149,12 +149,8 @@ table.comments {
       float: right;
     }
   }
-  tr:target {
-    td.comment {
-      div.commentinfo {
-        .table-header-alternative-target-gradient;
-      }
-    }
+  tr:target td.comment div.commentinfo {
+    background-color: @target-background;
   }
 }
 .action {


### PR DESCRIPTION
Current background is too dark (`#E95420`), see f.e. https://ikhaya.ubuntuusers.de/2020/01/26/neues-ubuntuusers-theme-kommt/#comment_1