### PR TITLE
NPM: Pin less and update dependecies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2765,9 +2765,9 @@
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
     },
     "less": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-3.9.0.tgz",
-      "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.10.3.tgz",
+      "integrity": "sha512-vz32vqfgmoxF1h3K4J+yKCtajH0PWmjkIFgbs5d78E/c/e+UQTnI+lWK+1eQRE95PXM2mC3rJlLSSP9VQHnaow==",
       "requires": {
         "clone": "^2.1.2",
         "errno": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-jshint": "~1.1.0",
     "grunt-contrib-less": "^2.0.0",
+    "less": "3.10.3",
     "grunt-contrib-nodeunit": "^2.0.0",
     "grunt-contrib-uglify": "~2.0.0",
     "grunt-contrib-watch": "^1.1.0",


### PR DESCRIPTION
Without pinning less, the CI does not run at the moment. See the commit messages for details.