### PR TITLE
Minor: Fix license warning in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/inyokaproject/theme-ubuntuusers"
   },
   "author": "Inyoka Team",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/inyokaproject/theme-ubuntuusers/issues"
   },


### PR DESCRIPTION
The term was for some reason shortened. It was already fixed in the
theme-default.