### PR TITLE
Add drop shadow to header

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/main.less
+++ b/inyoka_theme_ubuntuusers/static/style/main.less
@@ -605,6 +605,7 @@ table.syntaxtable {
   background-image: url(../img/head/trianglify_masked_optimized.svg);
   background-position: left top;
   background-repeat: no-repeat;
+  filter: drop-shadow(0px 5px 8px rgba(0, 0, 0, 0.15));
 
   .horizontal-space-big-width();
 


### PR DESCRIPTION
A drop shadow is a good visual effect for the wave as it highlights this
iconic ubuntuusers.de design element in the flat design language.

The pre-2020 design integrated the wave as well but the present solution
has a sharp transition. This will be smoothed out by this shadow.

The drop shadow is applied via a CSS3 filter which is supported in most
modern browsers: https://caniuse.com/css-filters