### PR TITLE
Show no custom background that repeats during advent

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/special_day/base_xmas.less
+++ b/inyoka_theme_ubuntuusers/static/style/special_day/base_xmas.less
@@ -1,7 +1,3 @@
-body {
-    background-image: url(../../img/head-xmas.jpg);
-}
-
 a.user {
     background-image: url(../../img/interwiki/user-xmas.png) !important;
 }


### PR DESCRIPTION
Otherwise the all portal parts (portal, wiki, forum etc.) would look like

![Portal_broken_ubuntuusers_portal](https://user-images.githubusercontent.com/2538080/100518836-6a1ae380-3194-11eb-94bc-f06083752261.png)
