### PR TITLE
Search parameters

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/overall.html
+++ b/inyoka_theme_ubuntuusers/templates/overall.html
@@ -167,7 +167,7 @@
 
             {# customization to duckduckgo layout, see https://duckduckgo.com/params #}
             <input type="hidden" name="kam" value="osm">
-            <input type="hidden" name="kj" value="D8A648">
+            <input type="hidden" name="kj" value="F4AA90">
             <input type="hidden" name="ka" value="Ubuntu">
 
             <input type="submit" value="{% trans %}Search{% endtrans %}" class="search_submit" />


### PR DESCRIPTION
Removed not supported search parameters and use F4AA90 (see [here](https://github.com/inyokaproject/theme-ubuntuusers/issues/370#issuecomment-738972576)) as header colour for DuckDuckGo search.