### PR TITLE
Closes #265: Added date separated with a dash to event

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/portal/calendar_overview.html
+++ b/inyoka_theme_ubuntuusers/templates/portal/calendar_overview.html
@@ -44,7 +44,7 @@
   {% if events %}
     <ul class="events vcalendar">
       {% for event in events %}
-      <li>{{ event.friendly_title(with_html_link=true) }} &ndash; {{ event.date|naturalday }}</li>
+      <li>{{ event.friendly_title(with_html_link=true) }} – {{ event.date|naturalday }}</li>
       {%- endfor %}
     </ul>
   {% else %}


### PR DESCRIPTION
Seperate the date on calendar page with a dash (no html entity).