### PR TITLE
Remove legacy table-header gradient mixins

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/ikhaya.less
+++ b/inyoka_theme_ubuntuusers/static/style/ikhaya.less
@@ -220,7 +220,7 @@ div.report {
   border: 1px solid #CCC;
   margin: 0 0 0.5em 0;
   .report_header {
-    .table-header-alternative-gradient;
+    background-color: #EAECEE;
     padding: 0.2em;
   }
   .text {
@@ -229,11 +229,11 @@ div.report {
 }
 
 div.solved .report_header {
-  .table-header-alternative-solved-gradient;
+  background-color: @green_d_light;
 }
 
 div.report:target .report_header {
-  .table-header-alternative-target-gradient;
+  background-color: @target-background;
 }
 table.events td.actions, table.events td.date, table.events td.author {
   margin-top: .2em;

--- a/inyoka_theme_ubuntuusers/static/style/layout.less
+++ b/inyoka_theme_ubuntuusers/static/style/layout.less
@@ -37,33 +37,6 @@
   border-bottom-right-radius: @radius;
 }
 
-/*
- * Gradient-mixins (Legacy)
- */
-.gradient(@from: #ccc, @to: #000, @default: #999) {
-  background: repeat-x @default; /* fallback */
-  background: linear-gradient(to bottom,  @from,  @to);
-}
-
-.table-header-gradient(@from: #2B2929, @to: #2B2929,
-    @default: #2B2929) {
-  .gradient(@from, @to, @default);
-}
-
-.table-header-alternative-gradient(@from: #EAECEE, @to: #EAECEE,
-    @default: #EAECEE) {
-  .gradient(@from, @to, @default);
-}
-
-.table-header-alternative-solved-gradient(@from: #3EB34F, @to: #3EB34F,
-    @default: #3EB34F) {
-  .gradient(@from, @to, @default);
-}
-
-.table-header-alternative-target-gradient(@from: #E95420, @to: #E95420,
-    @default: #E95420) {
-  .gradient(@from, @to, @default);
-}
 
 /*
  * Other mixins
@@ -72,6 +45,11 @@
 .break-word() {
   overflow-wrap: break-word; /* "newer" name; only supported in Chrome/Opera */
   word-wrap: break-word; /* "older" alternative name */
+}
+
+.gradient(@from: #ccc, @to: #000, @default: #999) {
+  background: repeat-x @default; /* fallback */
+  background: linear-gradient(to bottom,  @from,  @to);
 }
 
 .reset() {


### PR DESCRIPTION
The name of the mixins was misleading, as they used the same colors for a gradient.
Now, the mixins are replaced by `background-color`.