### PR TITLE
Do not use grunt-contrib-less@2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-contrib-compress": "^1.6.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-jshint": "~1.1.0",
-    "grunt-contrib-less": "^2.0.0",
+    "grunt-contrib-less": "~2.0.0",
     "grunt-contrib-nodeunit": "^2.1.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-postcss": "^0.8.0",


### PR DESCRIPTION
as it seems incompatibel with the (old) node version used on jenkins
with Ubuntu 16.04.