### PR TITLE
Macros, add_user_avatar: Remove fixed size

### DIFF
--- a/inyoka_theme_ubuntuusers/templates/macros.html
+++ b/inyoka_theme_ubuntuusers/templates/macros.html
@@ -108,9 +108,7 @@
 {% macro add_user_avatar(user, css_classes='avatar') %}
   <img class="{{ css_classes }}"
     src="{{ user.avatar_url|default(href('static', 'img', 'portal', 'usercp-profile.svg'), true)|e }}"
-    alt="{% trans user=user.username|e %}Avatar of {{ user }}{% endtrans %}"
-    height="96px"
-    width="96px"/>
+    alt="{% trans user=user.username|e %}Avatar of {{ user }}{% endtrans %}">
 {% endmacro %}
 
 {% macro create_title(breadcrumb_list) %}


### PR DESCRIPTION
It causes problems like wrong aspect ratio (if the avatar image is not
quadratic) or blurred upsacling, if an avatar is an rasterized image
with less resolution.

@KaiserBarbarossa As you changed it: what did you test or what was you reason you changed it? The commit message does not state any details,  so I'm asking. My changes could break a corner case i oversee currently.