### PR TITLE
Display reporting state inside topic

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/forum.less
+++ b/inyoka_theme_ubuntuusers/static/style/forum.less
@@ -344,6 +344,9 @@ table.topic {
 table.topic table td, table.topic table th {
   border: solid 1px #ccc;
 }
+.reported_topic {
+    color: black;
+}
 .action {
   background-repeat: no-repeat;
   padding-left: 20px;

--- a/inyoka_theme_ubuntuusers/templates/forum/topic.html
+++ b/inyoka_theme_ubuntuusers/templates/forum/topic.html
@@ -63,8 +63,17 @@
              id="{{ topic.slug }}">{% trans %}Mark as solved{% endtrans %}</a>
         {% endif %} |
       {% endif %}
-      <a href="{{ topic|url('report') }}"
-         class="action action_report">{% trans %}Report{% endtrans %}</a>
+      {% if topic.reported %}
+        {%- if can_moderate %}
+            <a href="{{ href('forum', 'reported_topics') }}"
+               class="action action_report admin_link">{% trans %}reported topic{% endtrans %}</a>
+        {%- else %}
+            <span class="action action_report reported_topic">{% trans %}reported topic{% endtrans %}</span>
+        {%- endif %}
+      {% else %}
+        <a href="{{ topic|url('report') }}"
+           class="action action_report">{% trans %}Report{% endtrans %}</a>
+      {% endif %}
     {% endif %}
   </span>
   {%- if can_moderate %}


### PR DESCRIPTION
If a topic is reported and the user can moderate the link is changed to
the overview of reported topics and if the user doesn’t has this
permission, the text only says that the topic is reported.

This closes #172 