### PR TITLE
Add margin-top to `<h5>` and `<h6>`

### DIFF
--- a/inyoka_theme_ubuntuusers/static/style/wiki.less
+++ b/inyoka_theme_ubuntuusers/static/style/wiki.less
@@ -45,7 +45,7 @@ table:not([class]), table[class^="zebra"] {
   }
 }
 
-h2, h3, h4 {
+h2, h3, h4, h5, h6 {
   margin-top: 1.4em;
 }
 #page, .preview {


### PR DESCRIPTION
For example after a code block, a `<h5>` had no spacing above it. See https://forum.ubuntuusers.de/topic/ueberschrift-4ter-ordnung-ohne-zeilenumbruch/