### PR TITLE
usercp subscription: Remove unsubscribe link

### DIFF
--- a/inyoka_theme_ubuntuusers/jinja2/portal/usercp/subscriptions.html
+++ b/inyoka_theme_ubuntuusers/jinja2/portal/usercp/subscriptions.html
@@ -73,7 +73,6 @@
                     -#}<img src="{{ href('static', 'img/icons/raw.svg') }}" alt="{% trans %}Revisions{% endtrans %}" height="16" width="16"/>{#-
                   -#}</a>
                 {%- endif %}
-                <a href="{{ object|url('unsubscribe', next=CURRENT_URL) }}">({% trans %}Unsubscribe{% endtrans %})</a>
               </td>
               <td class="read">
                 {%- if sub.notified %}


### PR DESCRIPTION
Especially on mobile devices it was easy to accidentialy unsubsribe from a thread. Now the link after the subscription is removed.
It is still possible to unsubscribe from one or multiple threads via the button at the bottom of the page.

This was requested in https://forum.ubuntuusers.de/topic/ist-es-moeglich-die-liste-der-abonnements-sich/