### PR TITLE
Fix Download link to use the correct domain

### DIFF
--- a/inyoka_theme_ubuntuusers/jinja2/portal/index.html
+++ b/inyoka_theme_ubuntuusers/jinja2/portal/index.html
@@ -18,7 +18,7 @@
     </div>
   {%- endif -%}
   <div class="container get_ubuntu">
-    <h3><a href="{{ get_ubuntu_link }}">{{ get_ubuntu_description }}</a></h3>
+    <h3><a href="{{ href('wiki', 'Downloads') }}">{% trans %}Downloads{% endtrans %}</a></h3>
   </div>
   <div class="container calendar">
     <div class="calendar link">


### PR DESCRIPTION
Inline the content, so it is evaluated at runtime.

At the moment, on production the link points to a inyokaproject.org domain, as the settings variable `INYOKA_GET_UBUNTU_LINK` is only evaluated once in the settings file. At the evaluation time, `BASE_DOMAIN_NAME` pointed to inyokaproject.org.

Reported via
https://forum.ubuntuusers.de/topic/ueberarbeitung-downloads/16/#post-9450665