### PR TITLE
Remove license classifier pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ version = "1.52.1"
 description = "Inyoka ubuntuusers theme"
 readme = "README.rst"
 keywords = [ "calendar", "django", "forum", "news", "planet", "wiki" ]
-license = { file = "LICENSE" }
+# https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
+license = "BSD-3-Clause"
+license-files = [ "LICENSE" ]
 authors = [
   { name = "Inyoka Team" },
 ]
@@ -17,7 +19,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Django",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3 :: Only",
   "Topic :: Internet :: WWW/HTTP"
 ]


### PR DESCRIPTION
Apply the same changes as in Inyoka:
https://github.com/inyokaproject/inyoka/commit/c09f16f014d89c05cedf323a0ac9d77379a3b3c5